### PR TITLE
Fix color when hovering in affix css

### DIFF
--- a/themes/hugo-creative-theme/static/css/creative.css
+++ b/themes/hugo-creative-theme/static/css/creative.css
@@ -235,7 +235,7 @@ figure.twitter-logo img {
 
     .navbar-default.affix .nav > li>a:hover,
     .navbar-default.affix .nav>li>a:focus:hover {
-        color: #e84661;
+        color: white;
     }
 }
 


### PR DESCRIPTION
**Problem**
1. Scroll down to the bottom to highlight "Tickets"
2. Hover over "Venue" or "Workshop"
3. You will see the following
<img width="245" alt="before" src="https://cloud.githubusercontent.com/assets/15604207/22449201/a2477d16-e799-11e6-8cdd-497268ba8227.png">

**Solution**
This PR fixes the problem, so that when hovering, you can still see the words "Venue" or "Workshop".
<img width="234" alt="after" src="https://cloud.githubusercontent.com/assets/15604207/22449204/a981e6de-e799-11e6-8408-217ece284ce0.png">

**Assumptions**
This is assuming that highlighting "Tickets" is the intended behaviour.