### PR TITLE
Do not highlight 'Tickets' when page is scrolled down

### DIFF
--- a/themes/hugo-creative-theme/static/css/creative.css
+++ b/themes/hugo-creative-theme/static/css/creative.css
@@ -225,18 +225,6 @@ figure.twitter-logo img {
     .navbar-default.affix .navbar-header .navbar-brand:focus {
         color: #6D9BF1;
     }
-
-    .navbar-default.affix .nav > li>a.tickets-btn,
-    .navbar-default.affix .nav>li>a:focus {
-        background-color: #e84661;
-        margin-left: 0;
-        color: #fff;
-    }
-
-    .navbar-default.affix .nav > li>a:hover,
-    .navbar-default.affix .nav>li>a:focus:hover {
-        color: #e84661;
-    }
 }
 
 @media(max-width: 500px) {


### PR DESCRIPTION
This supersedes #16.

As the website is now multipage, there is no need to specifically highlight 'Tickets' when the page is scrolled all the way to the bottom.

