### PR TITLE
Possibly fix #59

### DIFF
--- a/themes/hugo-creative-theme/static/css/creative.css
+++ b/themes/hugo-creative-theme/static/css/creative.css
@@ -328,6 +328,11 @@ h4.timeline-mono-header {
   padding: 1em 0;
 }
 
+.timeline-block[id]:not([id=""]) {
+  padding-top: 5em;
+  margin-top: -4em;
+}
+
 .timeline-time, .timeline-event {
   padding: 0;
 }


### PR DESCRIPTION
Fix fixed top nav covering the talk title when anchoring.
Only target timeline blocks with anchor ids (that contains values).